### PR TITLE
Integrate gutenberg-mobile release 1.51.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     ext.kotlin_ktx_version = '1.2.0'
     ext.wordPressUtilsVersion = '1.30.3-beta.3'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = 'v1.50.1'
+    ext.gutenbergMobileVersion = '2-4a620d4a78778a4357166fbf5a68abf90c507a96'
 
     repositories {
         google()


### PR DESCRIPTION
## Description
This PR incorporates the 1.51.0 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/enejb/gutenberg-mobile/pull/2

Release Submission Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.